### PR TITLE
ci: fix version parsing regex in auto-rebase

### DIFF
--- a/.github/workflows/rebase_latest_version.yml
+++ b/.github/workflows/rebase_latest_version.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo "DATA_LATEST_VERSION=\
           $(git for-each-ref --format='%(refname:short)' refs/remotes/origin \
-          | grep -Po '(?<=origin/)v\d.\d(.\d)?$' \
+          | grep -Po '(?<=origin\/)v\d+.\d+(.\d+)?$' \
           | sort -V | tail -n 1\
           )" >> $GITHUB_ENV
 


### PR DESCRIPTION
Adds support for version numbers > 9, since we are slowly approaching 0.9.0 this could become an issue :)

Regex can be checked here: https://regex101.com/r/2Aygm8/2