### PR TITLE
Ns/chore/zk ds size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,14 +15,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -75,7 +75,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -122,7 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "rayon",
 ]
 
@@ -212,7 +212,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
@@ -290,9 +290,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "cfg-if"
@@ -472,7 +472,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -498,7 +498,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -518,7 +518,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
 ]
@@ -649,15 +649,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "log"
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "paste"
@@ -722,14 +722,14 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fb7a99b37aaef4c7dd2fd15a819eb8010bfc7a2c2155230d51f497316cad6d"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "semver"
@@ -878,7 +878,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -897,7 +897,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -910,7 +919,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -926,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1033,8 +1055,8 @@ dependencies = [
 
 [[package]]
 name = "tfhe"
-version = "1.1.0-alpha.0"
-source = "git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl#6bbce66466486888ea043c06cd966e4e7aa918f1"
+version = "1.1.0"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0#69438d40a88d51239fbf7b8ffa8d9e6a8858fddb"
 dependencies = [
  "aligned-vec 0.6.4",
  "bincode",
@@ -1042,16 +1064,17 @@ dependencies = [
  "dyn-stack 0.11.0",
  "itertools 0.14.0",
  "paste",
- "pulp 0.21.4",
+ "pulp 0.21.5",
  "rand_core",
  "rayon",
  "serde",
  "sha3",
- "tfhe-csprng 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl)",
+ "strum 0.27.1",
+ "tfhe-csprng 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0)",
  "tfhe-fft 0.9.0",
  "tfhe-ntt 0.6.0",
- "tfhe-versionable 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl)",
- "tfhe-zk-pok 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl)",
+ "tfhe-versionable 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0)",
+ "tfhe-zk-pok 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0)",
 ]
 
 [[package]]
@@ -1130,16 +1153,16 @@ dependencies = [
  "ron",
  "semver",
  "serde",
- "strum",
+ "strum 0.26.3",
  "tfhe 0.10.0",
  "tfhe 0.11.3",
  "tfhe 0.8.7",
  "tfhe 1.0.0",
- "tfhe 1.1.0-alpha.0",
+ "tfhe 1.1.0",
  "tfhe-versionable 0.3.2",
  "tfhe-versionable 0.4.0",
  "tfhe-versionable 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tfhe-versionable 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl)",
+ "tfhe-versionable 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0)",
 ]
 
 [[package]]
@@ -1156,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "tfhe-csprng"
 version = "0.5.0"
-source = "git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl#6bbce66466486888ea043c06cd966e4e7aa918f1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0#69438d40a88d51239fbf7b8ffa8d9e6a8858fddb"
 dependencies = [
  "aes",
  "libc",
@@ -1196,14 +1219,14 @@ dependencies = [
 [[package]]
 name = "tfhe-fft"
 version = "0.9.0"
-source = "git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl#6bbce66466486888ea043c06cd966e4e7aa918f1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0#69438d40a88d51239fbf7b8ffa8d9e6a8858fddb"
 dependencies = [
  "aligned-vec 0.6.4",
  "bytemuck",
  "dyn-stack 0.11.0",
  "js-sys",
  "num-complex",
- "pulp 0.21.4",
+ "pulp 0.21.5",
  "serde",
 ]
 
@@ -1232,11 +1255,11 @@ dependencies = [
 [[package]]
 name = "tfhe-ntt"
 version = "0.6.0"
-source = "git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl#6bbce66466486888ea043c06cd966e4e7aa918f1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0#69438d40a88d51239fbf7b8ffa8d9e6a8858fddb"
 dependencies = [
  "aligned-vec 0.6.4",
  "bytemuck",
- "pulp 0.21.4",
+ "pulp 0.21.5",
 ]
 
 [[package]]
@@ -1278,12 +1301,12 @@ dependencies = [
 [[package]]
 name = "tfhe-versionable"
 version = "0.5.0"
-source = "git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl#6bbce66466486888ea043c06cd966e4e7aa918f1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0#69438d40a88d51239fbf7b8ffa8d9e6a8858fddb"
 dependencies = [
  "aligned-vec 0.6.4",
  "num-complex",
  "serde",
- "tfhe-versionable-derive 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl)",
+ "tfhe-versionable-derive 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0)",
 ]
 
 [[package]]
@@ -1294,7 +1317,7 @@ checksum = "a463428890873548472daba5bdcecfe34b89c98518b4bd6cbd8595ac48fc0771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1305,7 +1328,7 @@ checksum = "ecd3db096e2fb065e012a2f5f8e03789ff980109809e484165c8d7d728a8a11d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1316,17 +1339,17 @@ checksum = "f221336486fd08a09dcfd035845f18ae4b742bbf6b6c21dc2121f6b3322705f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "tfhe-versionable-derive"
 version = "0.5.0"
-source = "git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl#6bbce66466486888ea043c06cd966e4e7aa918f1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0#69438d40a88d51239fbf7b8ffa8d9e6a8858fddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1389,7 +1412,7 @@ dependencies = [
 [[package]]
 name = "tfhe-zk-pok"
 version = "0.5.0"
-source = "git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl#6bbce66466486888ea043c06cd966e4e7aa918f1"
+source = "git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0#69438d40a88d51239fbf7b8ffa8d9e6a8858fddb"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -1400,7 +1423,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha3",
- "tfhe-versionable 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?branch=am%2Ffeat%2Fnoise-squashing-hl)",
+ "tfhe-versionable 0.5.0 (git+https://github.com/zama-ai/tfhe-rs.git?tag=tfhe-rs-1.1.0)",
  "zeroize",
 ]
 
@@ -1449,7 +1472,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1471,7 +1494,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1487,42 +1510,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
-dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1542,5 +1545,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,19 +39,21 @@ tfhe_1_0 = { version = "=1.0.0", features = [
   "zk-pok",
   "experimental-force_fft_algo_dif4",
 ], package = "tfhe", optional = true }
+
+# From here on we need to use git tag dependencies because versions are semver compatibles
 tfhe_1_1 = { git = "https://github.com/zama-ai/tfhe-rs.git", features = [
   "boolean",
   "integer",
   "shortint",
   "zk-pok",
   "experimental-force_fft_algo_dif4",
-], package = "tfhe", branch = "am/feat/noise-squashing-hl", optional = true }
+], package = "tfhe", tag = "tfhe-rs-1.1.0", optional = true }
 
 # TFHE-rs 0.8 and 0.10 use the same version of versionable
 tfhe-versionable = { version = "0.3.2", optional = true, package = "tfhe-versionable" }
 tfhe_0_11-versionable = { version = "0.4.0", optional = true, package = "tfhe-versionable" }
 tfhe_1_0-versionable = { version = "0.5.0", optional = true, package = "tfhe-versionable" }
-tfhe_1_1-versionable = { version = "0.5.0", git = "https://github.com/zama-ai/tfhe-rs.git", branch = "am/feat/noise-squashing-hl", optional = true, package = "tfhe-versionable" }
+tfhe_1_1-versionable = { git = "https://github.com/zama-ai/tfhe-rs.git", tag = "tfhe-rs-1.1.0", optional = true, package = "tfhe-versionable" }
 
 
 # other deps

--- a/data/1_0/high_level_api/zk_pkev2_crs.bcode
+++ b/data/1_0/high_level_api/zk_pkev2_crs.bcode
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a399e9866ffe9110e6c42914daf246a551c06fa70f64f9b3f9b109a802db2e9d
+size 5569088

--- a/data/1_0/high_level_api/zk_pkev2_crs.cbor
+++ b/data/1_0/high_level_api/zk_pkev2_crs.cbor
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e615cbcbe08eeaf16688f2bd8bad302b7d7f1d6fe6c0b1ca061419c9aed5f06
+size 6528206

--- a/data/high_level_api.ron
+++ b/data/high_level_api.ron
@@ -74,8 +74,8 @@
         metadata: HlCiphertext((
             test_filename: "ct1",
             key_filename: "batch_1_client_key",
-            clear_value: 0,
             compressed: false,
+            clear_value: 0,
         )),
     ),
     (
@@ -84,8 +84,8 @@
         metadata: HlCiphertext((
             test_filename: "ct2",
             key_filename: "batch_1_client_key",
-            clear_value: 255,
             compressed: false,
+            clear_value: 255,
         )),
     ),
     (
@@ -94,8 +94,8 @@
         metadata: HlCiphertext((
             test_filename: "ct_compressed_seeded",
             key_filename: "batch_1_client_key",
-            clear_value: 255,
             compressed: true,
+            clear_value: 255,
         )),
     ),
     (
@@ -104,8 +104,8 @@
         metadata: HlCiphertext((
             test_filename: "ct_compressed_modswitched",
             key_filename: "batch_1_client_key",
-            clear_value: 255,
             compressed: true,
+            clear_value: 255,
         )),
     ),
     (
@@ -449,6 +449,19 @@
             test_filename: "server_key_ms_noise_reduction",
             client_key_filename: "client_key_ms_noise_reduction.cbor",
             compressed: false,
+        )),
+    ),
+    (
+        tfhe_version_min: "1.0",
+        tfhe_module: "high_level_api",
+        metadata: ZkPkePublicParams((
+            test_filename: "zk_pkev2_crs",
+            lwe_dimension: 2048,
+            max_num_cleartext: 16,
+            noise_bound: 46,
+            ciphertext_modulus: 18446744073709551616,
+            plaintext_modulus: 32,
+            padding_bit_count: 1,
         )),
     ),
     (

--- a/src/data_1_0.rs
+++ b/src/data_1_0.rs
@@ -1,17 +1,18 @@
 use crate::generate::{
     store_versioned_test_tfhe_1_0, TfhersVersion, INSECURE_SMALL_TEST_PARAMS_MS_NOISE_REDUCTION,
+    PRNG_SEED, VALID_TEST_PARAMS_TUNIFORM,
 };
 use crate::{
     HlClientKeyTest, HlServerKeyTest, TestDistribution, TestMetadata,
-    TestModulusSwitchNoiseReductionParams, TestParameterSet, HL_MODULE_NAME,
+    TestModulusSwitchNoiseReductionParams, TestParameterSet, ZkPkePublicParamsTest, HL_MODULE_NAME,
 };
 use std::borrow::Cow;
 use std::fs::create_dir_all;
 use tfhe_1_0::boolean::engine::BooleanEngine;
 use tfhe_1_0::core_crypto::commons::generators::DeterministicSeeder;
-use tfhe_1_0::core_crypto::commons::math::random::DefaultRandomGenerator;
+use tfhe_1_0::core_crypto::commons::math::random::{DefaultRandomGenerator, RandomGenerator};
 use tfhe_1_0::core_crypto::prelude::{
-    LweCiphertextCount, NoiseEstimationMeasureBound, RSigmaFactor, Variance,
+    LweCiphertextCount, NoiseEstimationMeasureBound, RSigmaFactor, TUniform, Variance,
 };
 use tfhe_1_0::shortint::engine::ShortintEngine;
 use tfhe_1_0::shortint::parameters::{
@@ -20,6 +21,8 @@ use tfhe_1_0::shortint::parameters::{
     MaxNoiseLevel, MessageModulus, ModulusSwitchNoiseReductionParams, PBSParameters,
     PolynomialSize, StandardDev,
 };
+use tfhe_1_0::zk::CompactPkeCrs;
+use tfhe_1_0::zk::ZkMSBZeroPaddingBitCount;
 use tfhe_1_0::Seed;
 
 macro_rules! store_versioned_test {
@@ -110,6 +113,22 @@ const HL_SERVERKEY_MS_NOISE_REDUCTION_TEST: HlServerKeyTest = HlServerKeyTest {
     compressed: false,
 };
 
+const ZK_PKEV2_CRS_TEST: ZkPkePublicParamsTest = ZkPkePublicParamsTest {
+    test_filename: Cow::Borrowed("zk_pkev2_crs"),
+    lwe_dimension: VALID_TEST_PARAMS_TUNIFORM.polynomial_size
+        * VALID_TEST_PARAMS_TUNIFORM.glwe_dimension, // Lwe dimension of the "big" key is glwe dimension * polynomial size
+    max_num_cleartext: 16,
+    noise_bound: match VALID_TEST_PARAMS_TUNIFORM.lwe_noise_distribution {
+        TestDistribution::Gaussian { .. } => unreachable!(),
+        TestDistribution::TUniform { bound_log2 } => bound_log2 as usize,
+    },
+    ciphertext_modulus: VALID_TEST_PARAMS_TUNIFORM.ciphertext_modulus,
+    plaintext_modulus: VALID_TEST_PARAMS_TUNIFORM.message_modulus
+        * VALID_TEST_PARAMS_TUNIFORM.carry_modulus
+        * 2, // *2 for padding bit
+    padding_bit_count: 1,
+};
+
 pub struct V1_0;
 
 impl TfhersVersion for V1_0 {
@@ -152,9 +171,26 @@ impl TfhersVersion for V1_0 {
             &HL_SERVERKEY_MS_NOISE_REDUCTION_TEST.test_filename,
         );
 
+        let mut zk_rng: RandomGenerator<DefaultRandomGenerator> =
+            RandomGenerator::new(Seed(PRNG_SEED));
+
+        let zkv2_crs = CompactPkeCrs::new(
+            LweDimension(ZK_PKEV2_CRS_TEST.lwe_dimension),
+            LweCiphertextCount(ZK_PKEV2_CRS_TEST.max_num_cleartext),
+            TUniform::<u64>::new(ZK_PKEV2_CRS_TEST.noise_bound as u32),
+            CiphertextModulus::new(ZK_PKEV2_CRS_TEST.ciphertext_modulus),
+            ZK_PKEV2_CRS_TEST.plaintext_modulus as u64,
+            ZkMSBZeroPaddingBitCount(ZK_PKEV2_CRS_TEST.padding_bit_count as u64),
+            &mut zk_rng,
+        )
+        .unwrap();
+
+        store_versioned_test!(&zkv2_crs, &dir, &ZK_PKEV2_CRS_TEST.test_filename,);
+
         vec![
             TestMetadata::HlClientKey(HL_CLIENTKEY_MS_NOISE_REDUCTION_TEST),
             TestMetadata::HlServerKey(HL_SERVERKEY_MS_NOISE_REDUCTION_TEST),
+            TestMetadata::ZkPkePublicParams(ZK_PKEV2_CRS_TEST),
         ]
     }
 }


### PR DESCRIPTION
Adds the PkeV2 CRS using TFHE-rs 1.0, it should have been added at this time.